### PR TITLE
chore: add AutoConfiguration.imports for Spring Boot 3.x compatibility

### DIFF
--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,3 @@
+de.idealo.kafka.deckard.configuration.DeckardPropertiesAutoConfiguration
+de.idealo.kafka.deckard.configuration.KafkaProducerAutoConfiguration
+de.idealo.kafka.deckard.configuration.BeanDefinitionRegistrarAutoConfiguration


### PR DESCRIPTION
After SpringBoot 3.x, the spring.factories mechanism for auto-configuration registration is deprecated in favor of the new META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports file.

To support both old and new Spring Boot versions, I added AutoConfiguration.imports and kept spring.factories.